### PR TITLE
service: Use sync pool for Sign/Verify request headers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,3 +18,6 @@ require (
 	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550
 	google.golang.org/grpc v1.24.0
 )
+
+// Used for debug reasons
+// replace github.com/nspcc-dev/neofs-crypto => ../neofs-crypto

--- a/service/verify_test.go
+++ b/service/verify_test.go
@@ -14,6 +14,57 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func BenchmarkSignRequestHeader(b *testing.B) {
+	key := test.DecodeKey(0)
+
+	custom := testCustomField{1, 2, 3, 4, 5, 6, 7, 8}
+
+	some := &TestRequest{
+		IntField:    math.MaxInt32,
+		StringField: "TestRequestStringField",
+		BytesField:  make([]byte, 1<<22),
+		CustomField: &custom,
+		RequestMetaHeader: RequestMetaHeader{
+			TTL:   math.MaxInt32 - 8,
+			Epoch: math.MaxInt64 - 12,
+		},
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		require.NoError(b, SignRequestHeader(key, some))
+	}
+}
+
+func BenchmarkVerifyRequestHeader(b *testing.B) {
+	custom := testCustomField{1, 2, 3, 4, 5, 6, 7, 8}
+
+	some := &TestRequest{
+		IntField:    math.MaxInt32,
+		StringField: "TestRequestStringField",
+		BytesField:  make([]byte, 1<<22),
+		CustomField: &custom,
+		RequestMetaHeader: RequestMetaHeader{
+			TTL:   math.MaxInt32 - 8,
+			Epoch: math.MaxInt64 - 12,
+		},
+	}
+
+	for i := 0; i < 10; i++ {
+		key := test.DecodeKey(i)
+		require.NoError(b, SignRequestHeader(key, some))
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		require.NoError(b, VerifyRequestHeader(some))
+	}
+}
+
 func TestSignRequestHeader(t *testing.T) {
 	req := &TestRequest{
 		IntField:    math.MaxInt32,


### PR DESCRIPTION
```
// Before
BenchmarkSignRequestHeader-8   	     146	   8070375 ns/op	 4210607 B/op	      48 allocs/op
BenchmarkVerifyRequestHeader-8   	      14	  83058325 ns/op	42085955 B/op	    1601 allocs/op

// After
BenchmarkSignRequestHeader-8   	     156	   7709172 ns/op	   33902 B/op	      45 allocs/op
BenchmarkVerifyRequestHeader-8   	      15	  76910232 ns/op	   54368 B/op	    1563 allocs/op

// Summary:
benchmark                          old ns/op     new ns/op     delta
BenchmarkSignRequestHeader-8       8070375       7709172       -4.48%
BenchmarkVerifyRequestHeader-8     83058325      76910232      -7.40%

benchmark                          old allocs     new allocs     delta
BenchmarkSignRequestHeader-8       48             45             -6.25%
BenchmarkVerifyRequestHeader-8     1601           1563           -2.37%

benchmark                          old bytes     new bytes     delta
BenchmarkSignRequestHeader-8       4210607       33902         -99.19%
BenchmarkVerifyRequestHeader-8     42085955      54368         -99.87%
```