### PR TITLE
session: Add public key to the constructor of new private token

### DIFF
--- a/session/service.go
+++ b/session/service.go
@@ -33,6 +33,7 @@ type (
 		LastEpoch  uint64
 		ObjectID   []ObjectID
 		OwnerID    OwnerID
+		PublicKeys [][]byte
 	}
 )
 

--- a/session/store.go
+++ b/session/store.go
@@ -54,6 +54,7 @@ func (s *simpleStore) New(p TokenParams) *PToken {
 			LastEpoch:  p.LastEpoch,
 			ObjectID:   p.ObjectID,
 			OwnerID:    p.OwnerID,
+			PublicKeys: p.PublicKeys,
 		},
 		PrivateKey: key,
 	}

--- a/session/store_test.go
+++ b/session/store_test.go
@@ -57,9 +57,14 @@ func TestTokenStore(t *testing.T) {
 
 	c := newTestClient(t)
 	require.NotNil(t, c)
+	pk := [][]byte{crypto.MarshalPublicKey(&c.PublicKey)}
 
 	// create new token
-	token := s.New(TokenParams{ObjectID: []ObjectID{oid}, OwnerID: c.OwnerID})
+	token := s.New(TokenParams{
+		ObjectID: []ObjectID{oid},
+		OwnerID: c.OwnerID,
+		PublicKeys: pk,
+	})
 	signToken(t, token, c)
 
 	// check that it can be fetched
@@ -68,7 +73,11 @@ func TestTokenStore(t *testing.T) {
 	require.Equal(t, token, t1)
 
 	// create and sign another token by the same client
-	t1 = s.New(TokenParams{ObjectID: []ObjectID{oid}, OwnerID: c.OwnerID})
+	t1 = s.New(TokenParams{
+		ObjectID: []ObjectID{oid},
+		OwnerID: c.OwnerID,
+		PublicKeys: pk})
+
 	signToken(t, t1, c)
 
 	data := []byte{1, 2, 3}


### PR DESCRIPTION
Private token based on the token with private key. Therefore
it must inherit public key field through constructor parameter.